### PR TITLE
Fix: Invalid docker-compose.yml

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ services:
       - 8006:8006
       - 3389:3389/tcp
       - 3389:3389/udp
-   volumes:
+    volumes:
       - ./windows:/storage
     restart: always
     stop_grace_period: 2m


### PR DESCRIPTION
There was one space missing and because of that `docker-compose.yml` was giving an error:
`yaml: line 1: did not find expected key`